### PR TITLE
Add support for more zone calls with a break out to a zone structure.

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,104 +34,66 @@ func NewConfigClient(conn connection) *ConfigClient {
 	}
 }
 
-const configGetZoneNamesMethod = "org.fedoraproject.FirewallD1.config.getZoneNames"
+// FirewallD config prefix.
+const firewalldConfig = "org.fedoraproject.FirewallD1.config."
+
+func (c *ConfigClient) callWithReturn(ctx context.Context, method string, returnArg interface{}, args ...interface{}) error {
+	call := newCall(firewalldConfig+method, 0).WithArguments(args...).WithReturns(returnArg)
+	return c.configPath.Call(ctx, call)
+}
 
 // Return list of zone names (permanent configuration).
 func (c *ConfigClient) GetZoneNames(
 	ctx context.Context) ([]string, error) {
 	var zoneNames []string
-	return zoneNames, c.configPath.Call(ctx,
-		newCall(configGetZoneNamesMethod, 0).
-			WithReturns(&zoneNames))
+	return zoneNames, c.callWithReturn(ctx, "getZoneNames", &zoneNames)
 }
-
-const configGetServiceNamesMethod = "org.fedoraproject.FirewallD1.config.getServiceNames"
 
 // Return list of service names (permanent configuration).
 func (c *ConfigClient) GetServiceNames(
 	ctx context.Context) ([]string, error) {
 	var serviceNames []string
-	return serviceNames, c.configPath.Call(ctx,
-		newCall(configGetServiceNamesMethod, 0).
-			WithReturns(&serviceNames))
+	return serviceNames, c.callWithReturn(ctx, "getServiceNames", &serviceNames)
 }
-
-const configListZonesMethod = "org.fedoraproject.FirewallD1.config.listZones"
 
 // List object paths of zones known to permanent environment.
 func (c *ConfigClient) ListZones(
 	ctx context.Context) (zonePaths []string, err error) {
-	return zonePaths, c.configPath.Call(ctx,
-		newCall(configListZonesMethod, 0).
-			WithReturns(&zonePaths))
+	return zonePaths, c.callWithReturn(ctx, "listZones", &zonePaths)
 }
-
-const configGetZoneByNameMethod = "org.fedoraproject.FirewallD1.config.getZoneByName"
 
 // Return object path (permanent configuration) of zone with given name.
 func (c *ConfigClient) GetZoneByName(
-	ctx context.Context, zoneName string) (zonePath string, err error) {
-	return zonePath, c.configPath.Call(ctx,
-		newCall(configGetZoneByNameMethod, 0).
-			WithArguments(zoneName).
-			WithReturns(&zonePath))
+	ctx context.Context, zoneName string) (zone *Zone, err error) {
+	var path string
+	err = c.callWithReturn(ctx, "getZoneByName", &path, zoneName)
+	if err != nil {
+		return
+	}
+	zone = new(Zone)
+	zone.Path = path
+	zone.configPath = c.conn.Object(dbusDest, path)
+	return
 }
-
-const configGetServiceByNameMethod = "org.fedoraproject.FirewallD1.config.getServiceByName"
 
 // Return object path (permanent configuration) of service with given name.
 func (c *ConfigClient) GetServiceByName(
 	ctx context.Context, serviceName string) (servicePath string, err error) {
-	return servicePath, c.configPath.Call(ctx,
-		newCall(configGetServiceByNameMethod, 0).
-			WithArguments(serviceName).
-			WithReturns(&servicePath))
+	return servicePath, c.callWithReturn(ctx, "getServiceByName", &servicePath, serviceName)
 }
 
-// Zone instance object interface
-const configZoneRemoveMethod = "org.fedoraproject.FirewallD1.config.zone.remove"
-
-// Remove zone with given settings into permanent configuration.
-func (c *ConfigClient) RemoveZone(
-	ctx context.Context, zoneName string) error {
-	path, err := c.GetZoneByName(ctx, zoneName)
-	if err != nil {
-		return err
-	}
-	return c.conn.Object(dbusDest, path).
-		Call(ctx, newCall(configZoneRemoveMethod, 0))
-}
-
-const addZoneMethod = "org.fedoraproject.FirewallD1.config.addZone"
-
-// Add zone with given settings into permanent configuration.
+// DEPRECATED: Add zone with given settings into permanent configuration.
+// Needs https://github.com/godbus/dbus/pull/329 before this can fully function.
 func (c *ConfigClient) AddZone(
 	ctx context.Context, zoneName string, settings ZoneSettings) error {
 	var z interface{}
-	return c.configPath.Call(ctx,
-		newCall(addZoneMethod, 0).
-			WithArguments(zoneName, settings.ToSlice()).
-			WithReturns(&z))
+	return c.callWithReturn(ctx, "addZone", &z, zoneName, settings.ToSlice())
 }
 
-const configZoneGetSettingsMethod = "org.fedoraproject.FirewallD1.config.zone.getSettings"
-
-// Return permanent settings of given zone.
-func (c *ConfigClient) GetZoneSettings(
-	ctx context.Context, zoneName string) (ZoneSettings, error) {
-	path, err := c.GetZoneByName(ctx, zoneName)
-	if err != nil {
-		return ZoneSettings{}, err
-	}
-
-	var zoneSettings []interface{}
-	err = c.conn.Object(dbusDest, path).
-		Call(ctx,
-			newCall(configZoneGetSettingsMethod, 0).
-				WithReturns(&zoneSettings))
-	if err != nil {
-		return ZoneSettings{}, err
-	}
-
-	return ZoneSettingsFromSlice(zoneSettings), nil
+// Add zone with given settings into permanent configuration.
+// Needs https://github.com/godbus/dbus/pull/329 before this can fully function.
+func (c *ConfigClient) AddZone2(
+	ctx context.Context, zoneName string, settings ZoneSettings) error {
+	var z interface{}
+	return c.callWithReturn(ctx, "addZone2", &z, zoneName, settings.ToMap2())
 }

--- a/examples/zones/main.go
+++ b/examples/zones/main.go
@@ -35,7 +35,7 @@ func main() {
 	exitOnErr(err)
 	fmt.Println("Initial Zones:", zones)
 
-	err = client.Config().AddZone(ctx, "test", firewalld.ZoneSettings{
+	err = client.Config().AddZone2(ctx, "test", firewalld.ZoneSettings{
 		Target: "default",
 	})
 	exitOnErr(err)
@@ -45,7 +45,10 @@ func main() {
 	exitOnErr(err)
 	fmt.Println("Updated Zones:", zones)
 
-	err = client.Config().RemoveZone(ctx, "test")
+	zone, err := client.Config().GetZoneByName(ctx, "test")
+	exitOnErr(err)
+
+	err = zone.Remove(ctx)
 	exitOnErr(err)
 	fmt.Println("Removed zone 'test'")
 }

--- a/zone_settings.go
+++ b/zone_settings.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2021 The routerd authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package firewalld
+
+import (
+	"github.com/godbus/dbus/v5"
+)
+
+type ZoneSettings struct {
+	Version         string
+	Name            string
+	Description     string
+	Target          string
+	Services        []string
+	Ports           []Port
+	ICMPBlocks      []string
+	Masquerade      bool
+	ForwardPorts    []ForwardPort
+	Interfaces      []string
+	SourceAddresses []string
+	RichRules       []string
+	Protocols       []string
+	SourcePorts     []Port
+	// Only compatible with version 2 of zone settings.
+	ICMPBlockInversion bool
+	Forwarded          bool
+	EgressPriority     int32
+	IngressPriority    int32
+}
+
+func ZoneSettingsFromSlice(s []interface{}) ZoneSettings {
+	return ZoneSettings{
+		Version:     s[0].(string),
+		Name:        s[1].(string),
+		Description: s[2].(string),
+		// UNUSED s[3].(bool)
+		Target:          s[4].(string),
+		Services:        s[5].([]string),
+		Ports:           interfaceSliceToPorts(s[6]),
+		ICMPBlocks:      toStringSlice(s[7]),
+		Masquerade:      s[8].(bool),
+		ForwardPorts:    interfaceSliceToForwardPorts(s[9]),
+		Interfaces:      s[10].([]string),
+		SourceAddresses: s[11].([]string),
+		RichRules:       s[12].([]string),
+		Protocols:       s[13].([]string),
+		SourcePorts:     interfaceSliceToPorts(s[14]),
+	}
+}
+
+func (z *ZoneSettings) ToSlice() []interface{} {
+	return []interface{}{
+		z.Version,
+		z.Name,
+		z.Description,
+		false, // UNUSED
+		z.Target,
+		z.Services,
+		portsToInterfaceSlice(z.Ports),
+		z.ICMPBlocks,
+		z.Masquerade,
+		forwardPortsToInterfaceSlice(z.ForwardPorts),
+		z.Interfaces,
+		z.SourceAddresses,
+		z.RichRules,
+		z.Protocols,
+		portsToInterfaceSlice(z.SourcePorts),
+		false, // needed but ???
+	}
+}
+
+func ZoneSettingsFromMap2(s map[string]dbus.Variant) ZoneSettings {
+	var zoneSettings ZoneSettings
+	val, ok := s["version"]
+	if ok {
+		zoneSettings.Version = val.Value().(string)
+	}
+	val, ok = s["short"]
+	if ok {
+		zoneSettings.Name = val.Value().(string)
+	}
+	val, ok = s["description"]
+	if ok {
+		zoneSettings.Description = val.Value().(string)
+	}
+	val, ok = s["target"]
+	if ok {
+		zoneSettings.Target = val.Value().(string)
+	}
+	val, ok = s["services"]
+	if ok {
+		zoneSettings.Services = val.Value().([]string)
+	}
+	val, ok = s["ports"]
+	if ok {
+		zoneSettings.Ports = interfaceSliceToPorts(val.Value())
+	}
+	val, ok = s["icmp_blocks"]
+	if ok {
+		zoneSettings.ICMPBlocks = toStringSlice(val.Value())
+	}
+	val, ok = s["masquerade"]
+	if ok {
+		zoneSettings.Masquerade = val.Value().(bool)
+	}
+	val, ok = s["forward_ports"]
+	if ok {
+		zoneSettings.ForwardPorts = interfaceSliceToForwardPorts(val.Value())
+	}
+	val, ok = s["interfaces"]
+	if ok {
+		zoneSettings.Interfaces = val.Value().([]string)
+	}
+	val, ok = s["sources"]
+	if ok {
+		zoneSettings.SourceAddresses = val.Value().([]string)
+	}
+	val, ok = s["rules_str"]
+	if ok {
+		zoneSettings.RichRules = val.Value().([]string)
+	}
+	val, ok = s["protocols"]
+	if ok {
+		zoneSettings.Protocols = val.Value().([]string)
+	}
+	val, ok = s["source_ports"]
+	if ok {
+		zoneSettings.SourcePorts = interfaceSliceToPorts(val.Value())
+	}
+	val, ok = s["icmp_block_inversion"]
+	if ok {
+		zoneSettings.ICMPBlockInversion = val.Value().(bool)
+	}
+	val, ok = s["forward"]
+	if ok {
+		zoneSettings.Forwarded = val.Value().(bool)
+	}
+	val, ok = s["egress_priority"]
+	if ok {
+		zoneSettings.EgressPriority = val.Value().(int32)
+	}
+	val, ok = s["ingress_priority"]
+	if ok {
+		zoneSettings.IngressPriority = val.Value().(int32)
+	}
+	return zoneSettings
+}
+
+func (z *ZoneSettings) ToMap2() map[string]dbus.Variant {
+	s := make(map[string]dbus.Variant)
+	s["version"] = dbus.MakeVariant(z.Version)
+	s["short"] = dbus.MakeVariant(z.Name)
+	s["description"] = dbus.MakeVariant(z.Description)
+	s["target"] = dbus.MakeVariant(z.Target)
+	s["services"] = dbus.MakeVariant(z.Services)
+	s["ports"] = dbus.MakeVariant(portsToInterfaceSlice(z.Ports))
+	s["icmp_blocks"] = dbus.MakeVariant(z.ICMPBlocks)
+	s["masquerade"] = dbus.MakeVariant(z.Masquerade)
+	s["forward_ports"] = dbus.MakeVariant(forwardPortsToInterfaceSlice(z.ForwardPorts))
+	s["interfaces"] = dbus.MakeVariant(z.Interfaces)
+	s["sources"] = dbus.MakeVariant(z.SourceAddresses)
+	s["rules_str"] = dbus.MakeVariant(z.RichRules)
+	s["protocols"] = dbus.MakeVariant(z.Protocols)
+	s["source_ports"] = dbus.MakeVariant(portsToInterfaceSlice(z.SourcePorts))
+	s["icmp_block_inversion"] = dbus.MakeVariant(z.ICMPBlockInversion)
+	s["forward"] = dbus.MakeVariant(z.Forwarded)
+	s["egress_priority"] = dbus.MakeVariant(z.EgressPriority)
+	s["ingress_priority"] = dbus.MakeVariant(z.IngressPriority)
+	return s
+}
+
+type Port struct {
+	Port     string
+	Protocol string
+}
+
+func PortFromSlice(s []string) Port {
+	return Port{
+		Port:     s[0],
+		Protocol: s[1],
+	}
+}
+
+func (p *Port) ToSlice() []interface{} {
+	return []interface{}{
+		p.Port,
+		p.Protocol,
+	}
+}
+
+type ForwardPort struct {
+	Port      string
+	Protocol  string
+	ToPort    string
+	ToAddress string
+}
+
+func ForwardPortFromSlice(s []string) ForwardPort {
+	return ForwardPort{
+		Port:      s[0],
+		Protocol:  s[1],
+		ToPort:    s[2],
+		ToAddress: s[3],
+	}
+}
+
+func (p *ForwardPort) ToSlice() []interface{} {
+	return []interface{}{
+		p.Port,
+		p.Protocol,
+		p.ToPort,
+		p.ToAddress,
+	}
+}
+
+func interfaceSliceToPorts(s interface{}) []Port {
+	var out []Port
+	for _, p := range toStringSliceSlice(s) {
+		out = append(out, PortFromSlice(p))
+	}
+	return out
+}
+
+func portsToInterfaceSlice(ports []Port) [][]interface{} {
+	var out [][]interface{}
+	for _, p := range ports {
+		out = append(out, p.ToSlice())
+	}
+	return out
+}
+
+func interfaceSliceToForwardPorts(s interface{}) []ForwardPort {
+	var out []ForwardPort
+	for _, p := range toStringSliceSlice(s) {
+		out = append(out, ForwardPort{
+			Port:      p[0],
+			Protocol:  p[1],
+			ToPort:    p[2],
+			ToAddress: p[3],
+		})
+	}
+	return out
+}
+
+func forwardPortsToInterfaceSlice(ports []ForwardPort) [][]interface{} {
+	var out [][]interface{}
+	for _, p := range ports {
+		out = append(out, p.ToSlice())
+	}
+	return out
+}
+
+func toStringSliceSlice(in interface{}) (out [][]string) {
+	topSlice, ok := in.([][]interface{})
+	if !ok {
+		return nil
+	}
+
+	for _, slice := range topSlice {
+		s := toStringSlice(slice)
+		if len(s) == 0 {
+			continue
+		}
+		out = append(out, s)
+	}
+	return
+}
+
+func toStringSlice(in interface{}) (out []string) {
+	slice, ok := in.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	for _, i := range slice {
+		s, ok := i.(string)
+		if !ok {
+			continue
+		}
+		out = append(out, s)
+	}
+	return
+}


### PR DESCRIPTION
For a project I'm working on, I needed the ability to update the default zone. Rather than making my own, I decided to update your project to support using the newer zone settings and additional methods.

In testing the update/add methods, I found that firewalld errors with `INVALID_TYPE: '['4242', 'udp']' not of type <class 'tuple'>, but <class 'list'>`. I'm guessing this is a newer firewalld requirement of dbus messages, and found that the dbus project has an issue to support it at  https://github.com/godbus/dbus/pull/329. With this bug, I decided to add support for the other methods.